### PR TITLE
트위터 입력창과의 폰트 종류를 통일

### DIFF
--- a/src/styles/komposer.css
+++ b/src/styles/komposer.css
@@ -41,7 +41,14 @@ textarea.komposer {
   outline: 0;
   resize: none;
   font-size: inherit;
-  font-family: 'Twemoji', sans-serif;
+  font-family: TwitterChirp,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
   background-color: inherit;
   color: inherit;
 }


### PR DESCRIPTION
이 PR은 단순한 css 수정으로 Komposer textarea의 `font-family`를 트위터의 입력창과 동일하게 수정합니다.
WebExtensions를 지원하는 Chrome(Blink based)과 Orion(WebKit based)에서 테스트하였습니다.

## Chrome

### 설치 전

![chrome_without](https://user-images.githubusercontent.com/1115741/181255180-bd759d88-ced3-47dd-92f4-aa0bb0fefc84.jpg)

### 현재 Komposer

![chrome_prev](https://user-images.githubusercontent.com/1115741/181255337-09649e5f-c8c6-4324-8306-161ea6bdc62f.jpg)

### PR 적용된 Komposer

![chrome_new](https://user-images.githubusercontent.com/1115741/181255400-af488f24-6937-463a-9b3f-6b4e573f3a49.jpg)
